### PR TITLE
Don't page through non posts

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -10,7 +10,7 @@
   <h1>{{ .Title }}</h1>
   {{ .Content }}
 
-  {{ range .Paginator.Pages }}
+  {{ range where .Paginator.Pages "Section" "posts" }}
   <div>
     <div>
       <a href="{{ .RelPermalink }}">


### PR DESCRIPTION
Previously this theme would display everything within content as if it were a new post to be listed. When I wanted to add a privacy policy it was also listing that and the same would be true for the terms and conditions or an about page which doesn't seem sensible.

This alters this behavior so that it only shows new posts.