### PR TITLE
Add header links partial

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -3,6 +3,7 @@
     {{ .Site.Title }}
   </a>
 
+  {{ partial "header_links.html" }}
   {{ $currentPage := . }}
   {{ with .Site.Menus.main }}
   <div class="UnderlineNav-body">

--- a/layouts/partials/header_links.html
+++ b/layouts/partials/header_links.html
@@ -1,0 +1,1 @@
+{{/* Intentionally left blank. Can be overwritten to include content head without removing everything given by this template */}}


### PR DESCRIPTION
Previously if you wanted to add anything to the header contents you
would need to copy all the code to the new partial. This leads to a lot
of duplication and makes merging upstream changes much more tricky.

This change allows loading another partial just before the menu items.